### PR TITLE
Fix null country and add coordinates

### DIFF
--- a/parkrun_api.py
+++ b/parkrun_api.py
@@ -35,19 +35,19 @@ class Country:
         countriesJson = session.get("https://images.parkrun.com/events.json").json()["countries"]
 
         for countryKey in countriesJson:
+            if countriesJson[countryKey]["url"] is not None:
+                country = Country(
+                    _id=countryKey,
+                    _url="https://" + countriesJson[countryKey]["url"]
+                    )
 
-            country = Country(
-                _id=countryKey, 
-                _url="https://" + countriesJson[countryKey]["url"]
-                )
-
-            countries.append(country)
+                countries.append(country)
 
         return countries
 
 class Event:
 
-    def __init__(self, _id=None, _name=None, _longName=None, _shortName=None, _countryCode=None, _seriesId=None, _location=None, _url=None):
+    def __init__(self, _id=None, _name=None, _longName=None, _shortName=None, _countryCode=None, _seriesId=None, _location=None, _coordinates=None, _url=None):
 
         self.id = _id
         self.name = _name
@@ -56,6 +56,8 @@ class Event:
         self.countryCode = _countryCode
         self.seriesId = _seriesId
         self.location = _location
+        self.latitude = _coordinates[1]
+        self.longitude = _coordinates[0]
         self.url = _url
         
         pass
@@ -76,7 +78,8 @@ class Event:
                 _shortName=event["properties"]["EventShortName"], 
                 _countryCode=event["properties"]["countrycode"], 
                 _seriesId=event["properties"]["seriesid"], 
-                _location=event["properties"]["EventLocation"]
+                _location=event["properties"]["EventLocation"],
+                _coordinates=event["geometry"]["coordinates"]
                 )
 
             events.append(event)


### PR DESCRIPTION
The dictionary of countries contains one "countre" that has no URL. The bounds of this country seem to wrap from west of the USA to east of New Zealand. I suspect this simply represents the span of all events around the globe, so can just be excluded entirely, so I've added `if countriesJson[countryKey]["url"] is not None` to skip it.

I was also surprised that the coordinates of an event weren't being recorded. I've also added that. I've confirmed that the latitude and longitude are correct by comparing the locations (using Google Maps) of three event's coordinates from the API to ones on the official parkrun map.